### PR TITLE
change dependabot.yml and downgrade two dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,13 @@
 version: 2
 updates:
   - package-ecosystem: "nuget"
-    directory: "/src"
+    directory: "/src/GreenEnergyHub.Conversion"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "NodaTime"
+        update-types: ["version-update:semver-patch"]
   - package-ecosystem: "nuget"
-    directory: "/test"
+    directory: "/test/GreenEnergyHub.Conversion.Tests"
     schedule:
       interval: "weekly"

--- a/src/GreenEnergyHub.Conversion/GreenEnergyHub.Conversion.csproj
+++ b/src/GreenEnergyHub.Conversion/GreenEnergyHub.Conversion.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 Licensed under the Apache License, Version 2.0 (the "License2");
 you may not use this file except in compliance with the License.
@@ -24,9 +24,9 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NodaTime" Version="3.0.5" />
+    <PackageReference Include="NodaTime" Version="3.0.4" />
     <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.0.0" />
-    <PackageReference Include="System.Text.Json" Version="5.0.2" />
+    <PackageReference Include="System.Text.Json" Version="5.0.1" />
   </ItemGroup>
 
   <Import Project="../../build/Common.props" />


### PR DESCRIPTION
Dependabot have caused some frustrations in the community due to the number of weekly PR's it creates.
A possible way to remedy this is by changing the Dependabot configuration file so that it e.g. won't bumb patch-updates.

This PR changes to Dependabot configuration file to illustrate how this approach:
Downgrade two dependencies of Conversion project to make them updateable.
Change Dependabot's configuration so that only one of them will be updated by Dependabot