### PR TITLE
Added time series terms to metering dictionary

### DIFF
--- a/docs/dictionary-and-concepts/dictionary-metering.md
+++ b/docs/dictionary-and-concepts/dictionary-metering.md
@@ -14,7 +14,7 @@ The terms listed here are all terms relating to the topics of defining metering.
 | **B** |   |
 | Business Reason Code | Indicates the business context, e.g. E23 = 'Periodic metering' used with time series |
 | **C** |   |
-| Created Date Time | A date and time property used in all messages exchanged with Green Energy Hub. It indicates when a particular message was created |
+| Created Date Time | A date and time property used in all messages exchanged with Green Energy Hub. It indicates when a particular message was created, and it is provided by the sender of the message |
 | Child Metering Point | a sub category of metering points that are all in relation to an accounting point  |
 | **D** |   |
 | Disconnection Type |  How the metering point can be disconnected |
@@ -47,7 +47,7 @@ The terms listed here are all terms relating to the topics of defining metering.
 | Out Area |  Indicates which grid an exchange point transports energy out of |
 | **P** |   |
 | Parent Metering Point | A term used when a Metering Point, or Accounting Point becomes part of a Metering Point Parent-Child hierachy, where the Parent acts as the top-level Metering Point. |
-| Point | One point equals one measurement within in time series. If a metering point is hourly read, a time series for a single day contains 24 points (Except for days switching between daylight saving time and standard time) |
+| Point | One point equals one measurement within a time series. If a metering point is hourly read, a time series for a single day contains 24 points (Except for days switching between daylight saving time and standard time) |
 | Position | Indicates the position of a measurement within a time series period |
 | Product | An energy product identification, e.g. active energy |
 | **Q** |   |

--- a/docs/dictionary-and-concepts/dictionary-metering.md
+++ b/docs/dictionary-and-concepts/dictionary-metering.md
@@ -12,43 +12,61 @@ The terms listed here are all terms relating to the topics of defining metering.
 | Accounting Point |  A domain under balance responsibility where Energy Supplier change can take place and for which commercial business processes are defined. **Additional information:** This is a type of Metering Point. |
 | Asset Type | The technology used on a specific metering point  |
 | **B** |   |
+| Business Reason Code | Indicates the business context, e.g. E23 = 'Periodic metering' used with time series |
 | **C** |   |
+| Created Date Time | A date and time property used in all messages exchanged with Green Energy Hub. It indicates when a particular message was created |
 | Child Metering Point | a sub category of metering points that are all in relation to an accounting point  |
 | **D** |   |
 | Disconnection Type |  How the metering point can be disconnected |
 | **E** |   |
+| End Date Time | A date and time indicating the end of a time series period |
 | Estimated Annual Volume | The predicted annual volume of consumed energy for an accounting point  |
 | Exchange Point |  A domain for establishing energy exchange between two Metering Grid Areas. **Additional information:** This is a type of Metering Point.|
 | **F** |   |
 | **G** |   |
 | **H** |   |
 | **I** |   |
+| Industry Classification | Indicates the industry context, e.g. E23 = Electricity |
 | In Area | Indicates which grid an exchange point transports energy into   |
 | **J** |   |
 | **K** |   |
 | **L** |   |
 | **M** |   |
 | Meter ID | ID for a physical device containing one or more registers.|
-| Metering Grid Area |  A Metering Grid Area is a physical area where consumption, production and exchange can be measured. It is delimited by the placement of meters for continuous measurement for input to, and withdrawal from the area. **Additional information:** It can be used to establish volumes that cannot be measured such as network losses. |
-| Metering Point | An entity where energy products are measured or computed.|
 | Meter Reading Periodicity| The frequency for which a metered data will be submitted |
 | Meter Type |  |
+| Metering Grid Area |  A Metering Grid Area is a physical area where consumption, production and exchange can be measured. It is delimited by the placement of meters for continuous measurement for input to, and withdrawal from the area. **Additional information:** It can be used to establish volumes that cannot be measured such as network losses. |
+| Metering Point | An entity where energy products are measured or computed.|
+| Metering Point ID | A unique metering point identifier |
+| Metering Point Type | Indicates the type of a metering point, e.g. Exchange |
 | MP Description | An option that can be used to describe how a physical meter can be located, e.g. basement |
 | Multiplier |  Meter conversion |
 | **N** |   |
 | **O** |   |
-| Out Area |  Indicates which grid an exchange point transports energy out of   |
+| Observation Time | A calculated value that indicates a date and time for a position in a time series |
+| Out Area |  Indicates which grid an exchange point transports energy out of |
 | **P** |   |
 | Parent Metering Point | A term used when a Metering Point, or Accounting Point becomes part of a Metering Point Parent-Child hierachy, where the Parent acts as the top-level Metering Point. |
+| Point | One point equals one measurement within in time series. If a metering point is hourly read, a time series for a single day contains 24 points (Except for days switching between daylight saving time and standard time) |
+| Position | Indicates the position of a measurement within a time series' period |
+| Product | An energy product identification, e.g. active energy |
 | **Q** |   |
-| Quantity | Quantity of a specific type of energy  |
+| Quantity | Quantity of a specific type of energy |
+| Quality | Indicates the quality of a specific quantity in a time series, e.g. estimated, measured, etc. |
 | **R** |   |
-| Rated Capacity | The maximum amount of power contracted for a metering point   |
-| Rated Current |  The maximum amount of current contracted for a metering point  |
-| Register | A physical or logical counter measuring energy products.|
+| Rated Capacity | The maximum amount of power contracted for a metering point |
+| Rated Current |  The maximum amount of current contracted for a metering point |
+| Register | A physical or logical counter measuring energy products |
+| Registration Date Time | A time series property indicating the point in time the time series measurements were read of the metering point |
+| Resolution | A resolution defines the precision a time series period is divided into. Expressed using ISO 8601, where e.g. 'PT1H' equals an hourly resolution |
 | **S** |   |
+| Settlement Method | A metering point's settlement method, e.g. flex settled |
+| Start Date Time | A date and time indicating the starting point of a time series period |
 | **T** |   |
+| Time series ID | A unique time series identifier provided by the sender |
+| Time series period | The time interval covered (by the time series) |
 | **U** |   |
+| Unit | The measure unit, e.g. kWh (kilowatt-hour) |
 | **W** |   |
 | **X** |   |
 | **Y** |   |

--- a/docs/dictionary-and-concepts/dictionary-metering.md
+++ b/docs/dictionary-and-concepts/dictionary-metering.md
@@ -36,19 +36,19 @@ The terms listed here are all terms relating to the topics of defining metering.
 | Meter Reading Periodicity| The frequency for which a metered data will be submitted |
 | Meter Type |  |
 | Metering Grid Area |  A Metering Grid Area is a physical area where consumption, production and exchange can be measured. It is delimited by the placement of meters for continuous measurement for input to, and withdrawal from the area. **Additional information:** It can be used to establish volumes that cannot be measured such as network losses. |
-| Metering Point | An entity where energy products are measured or computed.|
+| Metering Point | An entity where energy products are measured or computed |
 | Metering Point ID | A unique metering point identifier |
 | Metering Point Type | Indicates the type of a metering point, e.g. Exchange |
 | MP Description | An option that can be used to describe how a physical meter can be located, e.g. basement |
 | Multiplier |  Meter conversion |
 | **N** |   |
 | **O** |   |
-| Observation Time | A calculated value that indicates a date and time for a position in a time series |
+| Observation Time | A calculated value that indicates a date and time for a position in a time series period |
 | Out Area |  Indicates which grid an exchange point transports energy out of |
 | **P** |   |
 | Parent Metering Point | A term used when a Metering Point, or Accounting Point becomes part of a Metering Point Parent-Child hierachy, where the Parent acts as the top-level Metering Point. |
 | Point | One point equals one measurement within in time series. If a metering point is hourly read, a time series for a single day contains 24 points (Except for days switching between daylight saving time and standard time) |
-| Position | Indicates the position of a measurement within a time series' period |
+| Position | Indicates the position of a measurement within a time series period |
 | Product | An energy product identification, e.g. active energy |
 | **Q** |   |
 | Quantity | Quantity of a specific type of energy |
@@ -57,7 +57,7 @@ The terms listed here are all terms relating to the topics of defining metering.
 | Rated Capacity | The maximum amount of power contracted for a metering point |
 | Rated Current |  The maximum amount of current contracted for a metering point |
 | Register | A physical or logical counter measuring energy products |
-| Registration Date Time | A time series property indicating the point in time the time series measurements were read of the metering point |
+| Registration Date Time | A time series property indicating the point in time where the time series measurements were read of the metering point |
 | Resolution | A resolution defines the precision a time series period is divided into. Expressed using ISO 8601, where e.g. 'PT1H' equals an hourly resolution |
 | **S** |   |
 | Settlement Method | A metering point's settlement method, e.g. flex settled |

--- a/docs/dictionary-and-concepts/dictionary-metering.md
+++ b/docs/dictionary-and-concepts/dictionary-metering.md
@@ -12,7 +12,7 @@ The terms listed here are all terms relating to the topics of defining metering.
 | Accounting Point |  A domain under balance responsibility where Energy Supplier change can take place and for which commercial business processes are defined. **Additional information:** This is a type of Metering Point. |
 | Asset Type | The technology used on a specific metering point  |
 | **B** |   |
-| Business Reason Code | Indicates the business context, e.g. E23 = 'Periodic metering' used with time series |
+| Business Reason Code | Indicates the business context, e.g. 'Periodic metering' used with time series |
 | **C** |   |
 | Created Date Time | A date and time property used in all messages exchanged with Green Energy Hub. It indicates when a particular message was created, and it is provided by the sender of the message |
 | Child Metering Point | a sub category of metering points that are all in relation to an accounting point  |
@@ -26,8 +26,7 @@ The terms listed here are all terms relating to the topics of defining metering.
 | **G** |   |
 | **H** |   |
 | **I** |   |
-| Industry Classification | Indicates the industry context, e.g. E23 = Electricity |
-| In Area | Indicates which grid an exchange point transports energy into   |
+| In Area | Indicates which grid an exchange point transports energy into |
 | **J** |   |
 | **K** |   |
 | **L** |   |
@@ -43,7 +42,7 @@ The terms listed here are all terms relating to the topics of defining metering.
 | Multiplier |  Meter conversion |
 | **N** |   |
 | **O** |   |
-| Observation Time | A calculated value that indicates a date and time for a position in a time series period |
+| ObservationDateTime | A calculated value that indicates a date and time for a position in a time series period |
 | Out Area |  Indicates which grid an exchange point transports energy out of |
 | **P** |   |
 | Parent Metering Point | A term used when a Metering Point, or Accounting Point becomes part of a Metering Point Parent-Child hierachy, where the Parent acts as the top-level Metering Point. |


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/green-energy-hub) before we can accept your contribution. --->

## Description

This PR adds (approved) time series terms and definitions to the metering-dictionary.
Generic terms like, Document Type, Sender ID, CreatedDateTime, IndustyClassification, etc. are out of scope.

Notes: 
- TimeSeriesCommand has not been added as terms as this is more implementation oriented than language oriented.
- For now it has been decided that the dictionaries are located in the GEH repo. This might be changed later.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

https://github.com/Energinet-DataHub/geh-timeseries/issues/35
