### PR TITLE
3128: Change to maintained link checker

### DIFF
--- a/.github/workflows/md-check.yml
+++ b/.github/workflows/md-check.yml
@@ -36,7 +36,7 @@ jobs:
 
       # https://github.com/marketplace/actions/markdown-link-check
       - name: Markdown links check
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        uses: tcort/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: 'yes'
           use-verbose-mode: 'yes'


### PR DESCRIPTION
This pull request updates the Markdown link checker action in the GitHub Actions workflow file to use a different repository for the action.

Workflow update:

* [`.github/workflows/md-check.yml`](diffhunk://#diff-fdcb9d97f3e343cd33513ffa9a74c4d1a45b4bcb73194fb81591318faa363eb8L39-R39): Changed the `uses` directive for the Markdown link checker action from `gaurav-nelson/github-action-markdown-link-check@v1` (deprecated) to `tcort/github-action-markdown-link-check@v1`.