### PR TITLE
3395: Add permissions to workflows.

### DIFF
--- a/.github/workflows/license-check-ci.yml
+++ b/.github/workflows/license-check-ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   check-license-lines:
     name: Check License Lines

--- a/.github/workflows/md-check.yml
+++ b/.github/workflows/md-check.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   pre_job:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request makes a minor update to two GitHub Actions workflow files by explicitly setting the required permissions for the workflows. The change ensures that both workflows only have read access to repository contents, which is a security best practice.

- Security and permissions:
  * Added `permissions: contents: read` to `.github/workflows/license-check-ci.yml` to restrict workflow permissions.
  * Added `permissions: contents: read` to `.github/workflows/md-check.yml` to restrict workflow permissions.